### PR TITLE
Remove commons-io and use SpongeGradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,11 @@
-group 'org.spongepowered.ore'
-version '1.0-SNAPSHOT'
-
-apply plugin: 'java'
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
-repositories {
-    mavenCentral()
-    maven {
-        name 'sponge'
-        url 'http://repo.spongepowered.org/maven'
-    }
+plugins {
+    id 'org.spongepowered.plugin' version '0.7'
 }
+
+group = 'org.spongepowered'
+version = '1.0-SNAPSHOT'
+
+sponge.plugin.id = 'ore'
 
 dependencies {
     compile 'org.spongepowered:spongeapi:5.0.0-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,5 @@ repositories {
 }
 
 dependencies {
-    compile 'org.apache.commons:commons-io:1.3.2'
     compile 'org.spongepowered:spongeapi:5.0.0-SNAPSHOT'
-    testCompile group: 'junit', name: 'junit', version: '4.11'
 }

--- a/src/main/java/org/spongepowered/ore/OrePlugin.java
+++ b/src/main/java/org/spongepowered/ore/OrePlugin.java
@@ -36,7 +36,6 @@ import javax.inject.Inject;
  */
 @Plugin(id = "ore",
         name = "Ore",
-        version = "1.0.0",
         description = "Official package manager for Sponge.",
         authors = { "windy" }
 )

--- a/src/main/java/org/spongepowered/ore/client/SpongeOreClient.java
+++ b/src/main/java/org/spongepowered/ore/client/SpongeOreClient.java
@@ -12,10 +12,10 @@ import static org.spongepowered.ore.client.Routes.PROJECT_LIST;
 import static org.spongepowered.ore.client.Routes.USER;
 import static org.spongepowered.ore.client.Routes.VERSION;
 
-import org.apache.commons.io.FileUtils;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.plugin.PluginManager;
+import org.spongepowered.api.util.file.DeleteFileVisitor;
 import org.spongepowered.ore.OrePlugin;
 import org.spongepowered.ore.client.exception.NoUpdateAvailableException;
 import org.spongepowered.ore.client.exception.PluginAlreadyInstalledException;
@@ -33,6 +33,7 @@ import org.spongepowered.plugin.meta.PluginMetadata;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
@@ -256,7 +257,7 @@ public final class SpongeOreClient implements OreClient {
             move(updatePath, target);
         }
 
-        FileUtils.cleanDirectory(this.updatesDir.toFile());
+        Files.walkFileTree(this.updatesDir, DeleteFileVisitor.INSTANCE);
     }
 
     @Override


### PR DESCRIPTION
commons-io shouldn't be used (without shading) in Sponge plugins because it is only part of the implementation, but not available as dependency in SpongeAPI. I've added a NIO `DeleteFileVisitor` in https://github.com/SpongePowered/SpongeAPI/commit/e751b4a660c344304b658a1747a0c6b401158319 which you can also use in the Ore plugin now. (This will only work with the new API and implementation builds)

Also switched to SpongeGradle so the metadata version is automatically set to the version used in Gradle.
